### PR TITLE
fix(log): 修复JSON日志格式化错误并增强配置

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,14 @@ LLM_STREAMING="False"
 
 # 1. Dashscope (通义千问)
 # 当 LLM_PROVIDER="dashscope" 时需要
-DASHSCOPE_API_KEY="sk-1394205aa7234c89b714770291cdcf26"
+DASHSCOPE_API_KEY="sk-xxxxxxxxxxxxxxxxxxxxxx"
 
 # 2. vLLM (本地 OpenAI 兼容接口)
 # 当 LLM_PROVIDER="vllm" 时需要
 VLLM_API_BASE="http://localhost:8000/v1"
 VLLM_API_KEY="EMPTY" # vLLM 通常不需要 API Key，但客户端库可能需要一个非空值
+
+# Logging Configuration
+LOG_FORMAT="text"  # Log format: "text" for development, "json" for production
+LOG_LEVEL="INFO"   # Log level: TRACE, DEBUG, INFO, SUCCESS, WARNING, ERROR, CRITICAL
+LOG_FILE=""        # Log file path. If empty, logs will be sent to stdout/stderr. Example: "logs/app.log"

--- a/api/server.py
+++ b/api/server.py
@@ -3,8 +3,13 @@ import sys
 import os
 from fastapi import FastAPI
 from loguru import logger # 导入 logger
+from dotenv import load_dotenv
 
 from api.models import AgentRequest, AgentResponse
+
+# 在导入任何自定义模块之前加载 .env 文件
+# 这样可以确保所有配置在应用启动时都已准备就绪
+load_dotenv()
 
 # 将项目根目录添加到 sys.path，以确保可以正确导入 agent 和 tools
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/core/log_config.py
+++ b/core/log_config.py
@@ -1,7 +1,6 @@
 # core/log_config.py
 import sys
 import os
-import json
 import logging
 from loguru import logger
 
@@ -14,6 +13,7 @@ def setup_logging():
 
     - 在生产环境 (LOG_FORMAT="json")，日志将以 JSON 格式输出，便于机器解析和收集。
     - 在开发环境 (默认)，日志将以带颜色的、人类可读的文本格式输出。
+    - 支持通过 LOG_FILE 环境变量将日志同时输出到文件。
     """
     # 1. 移除 Loguru 默认的处理器，以便完全自定义
     logger.remove()
@@ -21,45 +21,47 @@ def setup_logging():
     # 2. 从环境变量读取日志级别和格式，提供默认值
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     log_format = os.getenv("LOG_FORMAT", "text").lower()
+    log_file = os.getenv("LOG_FILE", "")
 
-    # 3. 定义 JSON 格式化器
-    def json_formatter(record):
-        """
-        一个自定义的序列化器，用于将 Loguru 的记录对象转换为 JSON 字符串。
-        """
-        # 对于被拦截的日志，file.path 可能不存在，需要安全访问
-        file_path = record["file"].path if record.get("file") else "unknown"
-        
-        log_object = {
-            "timestamp": record["time"].isoformat(),
-            "level": record["level"].name,
-            "message": record["message"],
-            "source": {
-                "name": record["name"],
-                "file": file_path,
-                "line": record["line"],
-            },
-            **record["extra"],
-        }
-        return json.dumps(log_object, ensure_ascii=False) + "\\n"
-
-    # 4. 根据配置选择格式化器和输出目标
+    # 3. 根据配置选择格式化器和输出目标
     if log_format == "json":
-        # 生产环境：使用 JSON 格式
+        # 生产环境：使用 Loguru 内置的 JSON 序列化，这是最稳定可靠的方式。
+        # `serialize=True` 会自动将日志记录转换为 JSON 格式，包含所有核心信息。
         logger.add(
             sys.stdout,
             level=log_level,
-            format=json_formatter,
             serialize=True,
         )
     else:
-        # 开发环境：使用一个对所有日志记录都安全的标准格式
+        # 开发环境：使用对所有日志记录都安全的标准格式
         log_format_string = (
             "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
             "<level>{level: <8}</level> | "
             "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>"
         )
         logger.add(sys.stdout, level=log_level, colorize=True, format=log_format_string)
+
+    # 4. 如果配置了日志文件路径，则添加文件处理器
+    if log_file:
+        logger.info(f"日志也将被写入到文件: {log_file}")
+        try:
+            logger.add(
+                log_file,
+                level=log_level,
+                rotation="10 MB",       # 每 10 MB 切割
+                retention="7 days",     # 保留 7 天
+                compression="zip",      # 压缩旧文件
+                serialize=(log_format == "json"), # 如果是json格式，文件也用json
+                # 如果是文本格式，文件也用同样的文本格式
+                format=log_format_string if log_format != "json" else None,
+                # 确保文件写入是线程安全的
+                enqueue=True,
+                # 在程序退出时等待日志写完
+                catch=True,
+            )
+        except Exception as e:
+            logger.error(f"无法配置日志文件处理器: {e}")
+
 
     # 5. 关键一步：接管标准 `logging` 模块
     class InterceptHandler(logging.Handler):


### PR DESCRIPTION
- 彻底修复了在 `LOG_FORMAT="json"` 时因 `loguru` 配置不当引发的 `KeyError`。
- 重构 `core/log_config.py`，改用 `loguru` 内置的 `serialize=True` 参数处理JSON序列化，移除不稳定的手动格式化函数。
- 在 `api/server.py` 中集成 `python-dotenv`，以在本地开发环境中自动加载 `.env` 文件。
- 增强了文件日志功能，支持日志轮转、保留策略和压缩。
- 在 `.env.example` 中添加了 `LOG_FORMAT`, `LOG_LEVEL`, `LOG_FILE` 等常用日志配置项。